### PR TITLE
fix: chromium for firejail plus policies

### DIFF
--- a/flakes/shared.nix
+++ b/flakes/shared.nix
@@ -4,16 +4,18 @@ with inputs;
 rec {
   system = "x86_64-linux";
   stateVersion = "24.11";
-
-  pkgs = import nixpkgs {
-    inherit system;
-    overlays = [
-      nixgl.overlay
-      nur.overlays.default
-      alacritty-theme.overlays.default
-    ];
-    config = { allowUnfree = true; };
-  };
+  pkgs =
+    import
+      nixpkgs
+      {
+        inherit system;
+        overlays = [
+          nixgl.overlay
+          nur.overlays.default
+          alacritty-theme.overlays.default
+        ];
+        config = { allowUnfree = true; };
+      };
   pkgs_unstable = import
     nixpkgs_unstable
     {

--- a/flakes/system.nix
+++ b/flakes/system.nix
@@ -13,7 +13,7 @@ in
           sops-nix.nixosModules.sops
           lanzaboote.nixosModules.lanzaboote
         ]);
-        specialArgs = { inherit host_name host_attr; inherit (shared) pkgs_unstable system stateVersion users; };
+        specialArgs = { inherit host_name host_attr; inherit (shared) pkgs pkgs_unstable system stateVersion users; };
       }
     )
     shared.config_system.hosts;

--- a/programs/system/security/firejail/default.nix
+++ b/programs/system/security/firejail/default.nix
@@ -8,25 +8,45 @@ in
   # NOTE: Add shady apps to even more sandbox env
   config = mkIf cfg.enable {
 
-    programs.firejail = {
-      enable = true;
-      wrappedBinaries = {
-        viber = {
-          executable = "${pkgs.viber}/bin/viber";
-          desktop = "${pkgs.viber}/share/applications/viber.desktop";
-          extraArgs = [
-            "--noprofile"
-            "--env=GTK_THEME=Adwaita:dark"
-            "--dbus-user.talk=org.freedesktop.Notifications"
-            "--dbus-user.talk=org.freedesktop.ScreenSaver"
-            "--dbus-user.talk=org.freedesktop.portal.Desktop"
-            "--env=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus"
-          ];
-        };
-        chromium = {
-          executable = "${pkgs.chromium}/bin/chromium";
-          desktop = "${pkgs.chromium}/share/applications/chromium-browser.desktop";
-          profile = "${pkgs.chromium}/etc/firejail/chrome.profile";
+    programs = {
+      # INFO: Chromium policies
+      chromium = {
+        enable = true;
+        homepageLocation = "https://duckduckgo.com";
+        defaultSearchProviderSearchURL = "https://duckduckgo.com/?t=h_&q={searchTerms}";
+        extensions = [
+          # Dark reader
+          "eimadpbcbfnmbkopoojfekhnkhdbieeh"
+          # Ublock origin
+          "cjpalhdlnbpafiamejdnhcphjbkeiagm"
+          # Privacy Badger
+          "pkehgijcmpdhfbdbbnkijodmdjhbjlgp"
+          # User agent switcher
+          "bhchdcejhohfmigjafbampogmaanbfkg"
+          # Canvas blocker
+          "nomnklagbgmgghhjidfhnoelnjfndfpd"
+        ];
+      };
+
+      firejail = {
+        enable = true;
+        wrappedBinaries = {
+          viber = {
+            executable = "${pkgs.viber}/bin/viber";
+            desktop = "${pkgs.viber}/share/applications/viber.desktop";
+            extraArgs = [
+              "--noprofile"
+              "--env=GTK_THEME=Adwaita:dark"
+              "--dbus-user.talk=org.freedesktop.Notifications"
+              "--dbus-user.talk=org.freedesktop.ScreenSaver"
+              "--dbus-user.talk=org.freedesktop.portal.Desktop"
+              "--env=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus"
+            ];
+          };
+          chromium = {
+            executable = "${pkgs.chromium}/bin/chromium";
+            profile = "${pkgs.firejail}/etc/firejail/chromium.profile";
+          };
         };
       };
     };

--- a/programs/user/window-manager/i3wm/default.nix
+++ b/programs/user/window-manager/i3wm/default.nix
@@ -47,7 +47,7 @@ in
             shift = "Shift";
           in
           {
-            "${mod}+${ctrl}+c" = "exec ${pkgs.chromium}/bin/chromium";
+            "${mod}+${ctrl}+c" = "exec chromium";
             # "${mod}+${ctrl}+e" = "exec ${pkgs.microsoft-edge}/bin/microsoft-edge";
 
             "${mod}+${alt}+n" = "exec --no-startup-id pcmanfm ~/";


### PR DESCRIPTION
This pull request includes several changes to the NixOS configuration files, primarily focusing on package imports, special arguments, and program configurations.

### Package Imports and Special Arguments:

* [`flakes/shared.nix`](diffhunk://#diff-3e4949b989602d81eaf6b13002675641471cb7514698edacd36031efa14f770eL7-R10): Reformatted the `pkgs` import statement for better readability.
* [`flakes/system.nix`](diffhunk://#diff-843817591ba8968108da1ff445bf23d5142a2f100dcfcbfb772faf411a0508e8L16-R16): Added `pkgs` to the `specialArgs` attribute to be inherited from `shared`.

### Program Configurations:

* [`programs/system/security/firejail/default.nix`](diffhunk://#diff-59ab5e0c2c70462c9af98827e201452a1dcc40628c990857acd6d861640b78dcL11-R31): Added Chromium policies under the `programs` attribute and updated the `firejail` profile for Chromium. [[1]](diffhunk://#diff-59ab5e0c2c70462c9af98827e201452a1dcc40628c990857acd6d861640b78dcL11-R31) [[2]](diffhunk://#diff-59ab5e0c2c70462c9af98827e201452a1dcc40628c990857acd6d861640b78dcL28-R49)
* [`programs/user/window-manager/i3wm/default.nix`](diffhunk://#diff-b3e949ec9e8670613cc724368a3b9b814fc80041fcf959267b2ae4ac8de8a8a6L50-R50): Simplified the keybinding for launching Chromium by removing the full path to the executable.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added manual/automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Remark

For automation please see [closing-issues-using-keywords][closing_issues_using_keywords]

[closing_issues_using_keywords]: https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
