### PR TITLE
fix: librewolf profiles

### DIFF
--- a/home/dummy/options/librewolf/profiles/default.nix
+++ b/home/dummy/options/librewolf/profiles/default.nix
@@ -1,18 +1,16 @@
 { lib, config, pkgs }:
-let
-  plugins = if lib.hasAttr "nur" pkgs then pkgs.nur.repos.rycee.firefox-addons else lib.warn "> Firefox addons are not installed! Please install nur repository to add them!" { };
-in
+with pkgs.nur.repos.rycee.firefox-addons;
 {
   Dummy = {
     id = 0;
     name = "Dummy";
     containersForce = false;
     isDefault = true;
-    extensions = lib.mkIf (lib.hasAttr "firefox-addons" plugins) (with plugins;[
+    extensions = [
       ublock-origin
       privacy-badger
       i-dont-care-about-cookies
-    ]);
+    ];
   };
   Testarino = {
     id = 1;

--- a/home/ikostov2/options/librewolf/profiles/default.nix
+++ b/home/ikostov2/options/librewolf/profiles/default.nix
@@ -1,7 +1,6 @@
 { lib, config, pkgs, work_name, work_project1_name }:
-let
-  plugins = if lib.hasAttr "nur" pkgs then pkgs.nur.repos.rycee.firefox-addons else lib.warn "> Firefox addons are not installed! Please install nur repository to add them!" { };
-in
+with pkgs.nur.repos.rycee.firefox-addons;
+
 {
   Main = {
     id = 0;
@@ -9,14 +8,14 @@ in
     containersForce = true;
     isDefault = true;
     containers = import ./containers/Main;
-    extensions = lib.mkIf (lib.hasAttr "firefox-addons" plugins) (with plugins;[
+    extensions = [
       passbolt
       ublock-origin
       privacy-badger
       darkreader
       i-dont-care-about-cookies
       user-agent-string-switcher
-    ]);
+    ];
   };
   Youtube = {
     id = 1;
@@ -24,26 +23,26 @@ in
     containersForce = false;
     isDefault = false;
     containers = import ./containers/Youtube;
-    extensions = lib.mkIf (lib.hasAttr "firefox-addons" plugins) (with plugins;[
+    extensions = [
       ublock-origin
       privacy-badger
       darkreader
       i-dont-care-about-cookies
       user-agent-string-switcher
-    ]);
+    ];
   };
   Linked-In = {
     id = 2;
     name = "Linked-In";
     containersForce = false;
     isDefault = false;
-    extensions = lib.mkIf (lib.hasAttr "firefox-addons" plugins) (with plugins;[
+    extensions = [
       ublock-origin
       privacy-badger
       darkreader
       i-dont-care-about-cookies
       user-agent-string-switcher
-    ]);
+    ];
   };
 
   Work = {
@@ -51,14 +50,14 @@ in
     name = work_name;
     containersForce = false;
     isDefault = false;
-    extensions = lib.mkIf (lib.hasAttr "firefox-addons" plugins) (with plugins;[
+    extensions = [
       passbolt
       ublock-origin
       privacy-badger
       darkreader
       i-dont-care-about-cookies
       user-agent-string-switcher
-    ]);
+    ];
   };
 
   Work_Project1 = {
@@ -66,12 +65,12 @@ in
     name = work_project1_name;
     containersForce = false;
     isDefault = false;
-    extensions = lib.mkIf (lib.hasAttr "firefox-addons" plugins) (with plugins;[
+    extensions = [
       ublock-origin
       privacy-badger
       darkreader
       i-dont-care-about-cookies
       user-agent-string-switcher
-    ]);
+    ];
   };
 }


### PR DESCRIPTION
This pull request includes changes to simplify and improve the `librewolf` profile configuration files by removing unnecessary conditional checks and directly including the required Firefox add-ons. The most important changes include the removal of conditional checks for the presence of Firefox add-ons and the use of the `with` statement to include add-ons directly.

Improvements to `librewolf` profile configuration:

* [`home/dummy/options/librewolf/profiles/default.nix`](diffhunk://#diff-d1d2c65f6bbe222c768fd9cbb9235a62972eaf793dcc2f0f7d00fd0211458fe3L2-R13): Removed conditional checks for the presence of Firefox add-ons and directly included the required add-ons using the `with` statement.
* [`home/ikostov2/options/librewolf/profiles/default.nix`](diffhunk://#diff-8cea487c12b7985baee9b2af50e8e7e11809df6b01ddbe5cf9f3cbf1dbfd5dd1L2-R74): Removed conditional checks for the presence of Firefox add-ons and directly included the required add-ons using the `with` statement.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added manual/automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Remark

For automation please see [closing-issues-using-keywords][closing_issues_using_keywords]

[closing_issues_using_keywords]: https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
