### PR TITLE
fix: remove style option in modules

### DIFF
--- a/hosts/common/options/modules/default.nix
+++ b/hosts/common/options/modules/default.nix
@@ -50,11 +50,5 @@ _: {
         "rightalt" = "up";
       };
     };
-
-    style = {
-      enable = true;
-      theme = "kanagawa";
-      polarity = "dark";
-    };
   };
 }


### PR DESCRIPTION
M  hosts/common/options/modules/default.nix

# Description

- fix: style module

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added manual/automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Remark

For automation please see [closing-issues-using-keywords][closing_issues_using_keywords]

[closing_issues_using_keywords]: https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
