### PR TITLE
fix: pipewire

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -397,6 +397,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1783375776,
+        "narHash": "sha256-pg6hLjDeAWaUOzh2JM2Cw0BwYpGtOyNr6A4FBwP9Ymo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cd648d6ea62bc0ffba91e61fcfe5e33c1e2004b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1782614948,
@@ -543,6 +559,7 @@
         "lanzaboote": "lanzaboote",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "sops-nix": "sops-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,8 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-2511.url = "github:nixos/nixpkgs/release-25.11";
+
     devenv.url = "github:cachix/devenv";
     nur.url = "github:nix-community/NUR";
 

--- a/flakes/shared.nix
+++ b/flakes/shared.nix
@@ -74,6 +74,14 @@ with inputs; rec {
       config = {allowUnfree = true;};
     };
 
+  pkgs-2511 =
+    import
+    nixpkgs-2511
+    {
+      inherit system;
+      config = {allowUnfree = true;};
+    };
+
   config_system =
     import
     ../config.nix

--- a/flakes/system.nix
+++ b/flakes/system.nix
@@ -21,7 +21,7 @@ in {
 
           specialArgs = {
             inherit host_name host_attr;
-            inherit (shared) pkgs-unstable system stateVersion users;
+            inherit (shared) pkgs-unstable pkgs-2511 system stateVersion users;
           };
         }
     )

--- a/hosts/common/hardware/bluetooth/default.nix
+++ b/hosts/common/hardware/bluetooth/default.nix
@@ -1,9 +1,10 @@
-_: {
+{pkgs-2511, ...}: {
   hardware.bluetooth = {
     enable = true;
     powerOnBoot = true;
-    settings.Policy.AutoEnable = "true";
+    package = pkgs-2511.bluez;
     settings = {
+      Policy.AutoEnable = "true";
       General = {
         Name = "Computer";
         ControllerMode = "dual";

--- a/hosts/common/options/pipewire/default.nix
+++ b/hosts/common/options/pipewire/default.nix
@@ -1,6 +1,7 @@
-_: {
+{pkgs-2511, ...}: {
   services.pipewire = {
     enable = true;
+    package = pkgs-2511.pipewire;
     alsa = {
       enable = true;
       support32Bit = true;
@@ -10,6 +11,7 @@ _: {
     pulse.enable = true;
     wireplumber = {
       enable = true;
+      package = pkgs-2511.wireplumber;
       extraConfig.bluetoothEnhancements = {
         "monitor.bluez.properties" = {
           "bluez5.enable-sbc-xq" = true;


### PR DESCRIPTION
M  flake.lock
M  flake.nix
M  flakes/shared.nix
M  flakes/system.nix
M  hosts/common/hardware/bluetooth/default.nix
M  hosts/common/options/pipewire/default.nix

# Description

- fix bluetooth issue connecting with Google Nest 2 by reverting back to 25.11

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added manual/automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Remark

For automation please see [closing-issues-using-keywords][closing_issues_using_keywords]

[closing_issues_using_keywords]: https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
